### PR TITLE
Avoid division by zero in eventmain template when there are no uploads

### DIFF
--- a/templates/country.html
+++ b/templates/country.html
@@ -38,9 +38,9 @@ f/f3/LUSITANA_WLM_2011_d.svg/100px-LUSITANA_WLM_2011_d.svg.png{% endif %}" style
     <tr>
         <td><a href="{{ url_for('.index') }}{{ name }}/{{ year }}">{{ year }}</a></td>
         <td style="background-color:#F8F8F8"><a href="{{ url_for('index') }}images?event={{ name }}&year={{ year }}&country={{ country }}">{{ d['count'] }}</a></td>
-        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'])|int }}%)</td>
+        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'] if d['count'] != 0 else 0)|int }}%)</td>
         <td style="background-color:#F8F8F8"><a href="{{ url_for('.index') }}{{ name }}/{{ year }}/{{ country }}">{{ d['usercount'] }}</td>
-        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'])|int }}%)</td>
+        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'] if d['usercount'] != 0 else 0)|int }}%)</td>
     </tr>{% endfor %}
 </table><br/><br/>
 {% endfor %}

--- a/templates/eventmain.html
+++ b/templates/eventmain.html
@@ -44,9 +44,9 @@ f/f3/LUSITANA_WLM_2011_d.svg/100px-LUSITANA_WLM_2011_d.svg.png{% endif %}" style
     <tr>
         <td><a href="{{ url_for('index') }}{{ name }}/{{ year }}">{{ year }}</a></td>
         <td style="background-color:#F8F8F8">{{ d['count'] }}</td>
-        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'])|int }}%)</td>
+        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'] if d['count'] != 0 else 0)|int }}%)</td>
         <td style="background-color:#F8F8F8">{{ d['usercount'] }}</td>
-        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'])|int }}%)</td>
+        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'] if d['usercount'] != 0 else 0))|int }}%)</td>
     </tr>{% endfor %}
 </table><br/>
 <p>Below are the graphs per country.</p><br/>
@@ -68,9 +68,9 @@ f/f3/LUSITANA_WLM_2011_d.svg/100px-LUSITANA_WLM_2011_d.svg.png{% endif %}" style
     <tr>
         <td>{{ year }}</td>
         <td style="background-color:#F8F8F8"><a href="{{ url_for('index') }}images?event={{ name }}&year={{ year }}&country={{ country }}">{{ d['count'] }}</a></td>
-        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'])|int }}%)</td>
+        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'] if d['count'] != 0 else 0)|int }}%)</td>
         <td style="background-color:#F8F8F8"><a href="/{{ name }}/{{ year }}/{{ country }}">{{ d['usercount'] }}</td>
-        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'])|int }}%)</td>
+        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'] if d['usercount'] != 0 else 0)|int }}%)</td>
     </tr>{% endfor %}
 </table><br/><br/>
 {% endfor %}

--- a/templates/mainpage.html
+++ b/templates/mainpage.html
@@ -33,9 +33,9 @@ var data = [
     <tr>
         <td><a href="{{ url_for('index') }}earth/{{ year }}">{{ year }}</a></td>
         <td style="background-color:#F8F8F8">{{ d['count'] }}</td>
-        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'])|int }}%)</td>
+        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'] if d['count'] != 0 else 0)|int }}%)</td>
         <td style="background-color:#F8F8F8">{{ d['usercount'] }}</td>
-        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'])|int }}%)</td>
+        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'] if d['usercount'] != 0 else 0)|int }}%)</td>
     </tr>{% endfor %}
 </table>
 <br/><br/>
@@ -54,9 +54,9 @@ var data = [
     <tr>
         <td><a href="{{ url_for('index') }}monuments/{{ year }}">{{ year }}</a></td>
         <td style="background-color:#F8F8F8">{{ d['count'] }}</td>
-        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'])|int }}%)</td>
+        <td>{{ d['usage'] }} ({{ (100 * d['usage'] / d['count'] if d['count'] != 0 else 0)|int }}%)</td>
         <td style="background-color:#F8F8F8">{{ d['usercount'] }}</td>
-        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'])|int }}%)</td>
+        <td>{{ d['userreg'] }} ({{ (100 * d['userreg'] / d['usercount'] if d['usercount'] != 0 else 0)|int }}%)</td>
     </tr>{% endfor %}
 </table>
 <br/><br/>


### PR DESCRIPTION
For every country for every competition, the tool computes
the file usage rate and the percentage of new users.

This is computed in the Jinja template by dividing by the
upload count and the uploader count, which results in
a ZeroDivisionError when there have been no uploads yet.

Now, if the upload[er] count is zero, we do not compute
and return a percentage of zero directly.
